### PR TITLE
Handle large snapshots specially

### DIFF
--- a/server/auth/pubnub.ts
+++ b/server/auth/pubnub.ts
@@ -39,7 +39,8 @@ export async function publishWriteForRef(
 				JSON.stringify({
 					message: "Here's your data",
 					dataType: "parent" in ref ? "single" : "multiple",
-					data: newData,
+					shouldFetch: !("parent" in ref), // collections are too large to send via PubNub
+					data: "parent" in ref ? newData : [],
 					timestamp: Date.now(), // so the ciphertext is different each time
 				}),
 				cipherKey
@@ -47,6 +48,7 @@ export async function publishWriteForRef(
 			return pubnub.publish({
 				channel,
 				message,
+				sendByPost: true,
 			});
 		});
 		console.debug(`Posted write for channel '${channel}'`);

--- a/src/transport/onSnapshot.ts
+++ b/src/transport/onSnapshot.ts
@@ -461,7 +461,7 @@ export function onSnapshot<T extends DocumentData>(
 				} catch (error) {
 					let message: unknown;
 					if (error instanceof StructError) {
-						message = error.message;
+						message = `${error.message} at path '${error.path.join(".")}'`;
 					} else {
 						message = error;
 					}

--- a/src/transport/onSnapshot.ts
+++ b/src/transport/onSnapshot.ts
@@ -445,8 +445,10 @@ export function onSnapshot<T extends DocumentData>(
 				try {
 					const rawData: unknown = pubnub.decrypt(event.message as string | object, cipherKey);
 					if (typeof rawData === "string") {
+						console.debug("[onSnapshot] Parsing data from message string");
 						data = JSON.parse(rawData) as unknown;
 					} else {
+						console.debug("[onSnapshot] Taking message as data");
 						data = rawData;
 					}
 				} catch (error) {


### PR DESCRIPTION
Snapshot messages for large collections may be too large to send via PubNub, for obvious reasons. Arbitrarily-large messages are now truncated and sent with a flag informing clients that they should fetch that data directly.