### PR TITLE
feat: Autofocus and autosubmit the TOTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.4] - 2022-11-15
+### Added
+- Autofocus the TOTP field.
+- Autosubmit the TOTP on paste.
+
 ## [0.14.3] - 2022-11-11
 ### Changed
 - Improved our back-end logging to make transport and formatting middleware easy to install and change.
@@ -332,6 +337,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial commit
 
+[0.14.4]: https://github.com/AverageHelper/accountable-svelte/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/AverageHelper/accountable-svelte/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/AverageHelper/accountable-svelte/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/AverageHelper/accountable-svelte/compare/v0.14.0...v0.14.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "accountable-svelte",
-	"version": "0.14.3",
+	"version": "0.14.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "accountable-svelte",
-			"version": "0.14.3",
+			"version": "0.14.4",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@averagehelper/job-queue": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "accountable-svelte",
-	"version": "0.14.3",
+	"version": "0.14.4",
 	"license": "GPL-3.0",
 	"description": "A Svelte app for managing monetary assets.",
 	"scripts": {

--- a/src/components/inputs/TextField.svelte
+++ b/src/components/inputs/TextField.svelte
@@ -11,6 +11,7 @@
 		keydown: KeyboardEvent;
 		keyup: KeyboardEvent;
 		keypress: KeyboardEvent;
+		paste: ClipboardEvent;
 	}>();
 
 	type TextFieldType =
@@ -138,6 +139,10 @@
 		dispatch("keypress", event);
 	}
 
+	function onPaste(event: ClipboardEvent): void {
+		dispatch("paste", event);
+	}
+
 	export function focus(): void {
 		input?.focus();
 	}
@@ -200,6 +205,7 @@
 			on:keydown={onKeyDown}
 			on:keyup={onKeyUp}
 			on:keypress={onKeyPress}
+			on:paste={onPaste}
 		/>
 	{/if}
 

--- a/src/pages/auth/Locked.svelte
+++ b/src/pages/auth/Locked.svelte
@@ -51,7 +51,10 @@
 		event.stopPropagation();
 		event.preventDefault();
 		await tick();
-		submit();
+		if (token.length === 6 && /^\d+$/.test(token)) {
+			// Only if six digits
+			submit();
+		}
 	}
 
 	async function submit() {

--- a/src/pages/auth/Locked.svelte
+++ b/src/pages/auth/Locked.svelte
@@ -2,7 +2,7 @@
 	import { _ } from "../../i18n";
 	import { AccountableError, NetworkError } from "../../transport/errors";
 	import { accountsPath } from "../../router";
-	import { onMount } from "svelte";
+	import { onMount, tick } from "svelte";
 	import { useNavigate } from "svelte-navigator";
 	import ActionButton from "../../components/buttons/ActionButton.svelte";
 	import ErrorNotice from "../../components/ErrorNotice.svelte";
@@ -27,11 +27,17 @@
 	let isLoading = false;
 
 	let passwordField: TextField | undefined;
+	let totpField: TextField | undefined;
 
 	onMount(() => {
 		passwordField?.focus();
 		bootstrap();
 	});
+
+	$: if (needsTotp) {
+		// Focus the field when we enter TOTP mode
+		totpField?.focus();
+	}
 
 	function onPasswordInput(event: CustomEvent<string>) {
 		password = event.detail;
@@ -39,6 +45,13 @@
 
 	function onTotpInput(event: CustomEvent<string>) {
 		token = event.detail;
+	}
+
+	async function onTotpPaste(event: CustomEvent<ClipboardEvent>) {
+		event.stopPropagation();
+		event.preventDefault();
+		await tick();
+		submit();
 	}
 
 	async function submit() {
@@ -83,8 +96,10 @@
 
 			{#if needsTotp}
 				<TextField
+					bind:this={totpField}
 					value={token}
 					on:input={onTotpInput}
+					on:paste={onTotpPaste}
 					disabled={isLoading}
 					label={$_("login.totp")}
 					placeholder={$_("example.totp-code")}

--- a/src/pages/auth/Login.svelte
+++ b/src/pages/auth/Login.svelte
@@ -118,7 +118,10 @@
 		event.stopPropagation();
 		event.preventDefault();
 		await tick();
-		submit();
+		if (token.length === 6 && /^\d+$/.test(token)) {
+			// Only if six digits
+			submit();
+		}
 	}
 
 	function onUpdatePassphrase(event: CustomEvent<string>) {

--- a/src/pages/auth/Login.svelte
+++ b/src/pages/auth/Login.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { _ } from "../../i18n";
 	import { accountsPath, loginPath, signupPath } from "../../router";
-	import { onMount } from "svelte";
+	import { onMount, tick } from "svelte";
 	import { repoReadmeHeading } from "../../platformMeta";
 	import { AccountableError, UnreachableCaseError } from "../../transport/errors";
 	import { useLocation, useNavigate } from "svelte-navigator";
@@ -51,6 +51,7 @@
 
 	let accountIdField: TextField | undefined;
 	let passwordField: TextField | undefined;
+	let totpField: TextField | undefined;
 	let needsTotp = false;
 
 	onMount(() => {
@@ -80,6 +81,11 @@
 		}
 	}
 
+	$: if (isTotpMode) {
+		// Focus the field when we enter TOTP mode
+		totpField?.focus();
+	}
+
 	function enterSignupMode() {
 		accountId = "";
 		navigate(signupPath(), { replace: true });
@@ -106,6 +112,13 @@
 
 	function onUpdateTotp(event: CustomEvent<string>) {
 		token = event.detail;
+	}
+
+	async function onTotpPaste(event: CustomEvent<ClipboardEvent>) {
+		event.stopPropagation();
+		event.preventDefault();
+		await tick();
+		submit();
 	}
 
 	function onUpdatePassphrase(event: CustomEvent<string>) {
@@ -197,8 +210,10 @@
 				/>
 			{:else if isTotpMode}
 				<TextField
+					bind:this={totpField}
 					value={token}
 					on:input={onUpdateTotp}
+					on:paste={onTotpPaste}
 					disabled={isLoading}
 					label={$_("login.totp")}
 					placeholder={$_("example.totp-code")}


### PR DESCRIPTION
Most self-respecting TOTP fields autofocus the field. Let's do that.

GitHub has this nice feature where if you paste your TOTP in, it'll autosubmit! Maybe that's just a character count thing, idk. Anywho, let's at least autosubmit on paste (but only if the pasted value is a six-digit string).